### PR TITLE
Fix auction overview selected team handling

### DIFF
--- a/web/src/simulation.worker.js
+++ b/web/src/simulation.worker.js
@@ -314,7 +314,17 @@ export const evaluateOverview = (data = {}) => {
   const rules = normalizeRules(data.rules);
   const roles = Object.keys(rules.rosterSlots);
   const teams = Array.isArray(data.teams) ? data.teams : [];
-  const team = teams[0] || data.mine || { credits: 0, roster: [] };
+  const requestedOwner = Number(data.owner);
+  const mineIndex = teams.indexOf(data.mine);
+  const ownerIndex =
+    Number.isInteger(requestedOwner) &&
+    requestedOwner >= 0 &&
+    requestedOwner < teams.length
+      ? requestedOwner
+      : mineIndex >= 0
+        ? mineIndex
+        : 0;
+  const team = teams[ownerIndex] || data.mine || { credits: 0, roster: [] };
   const pool = Array.isArray(data.remaining) ? data.remaining : [];
   const needs = roleNeeds(team, rules);
   const slotsOpen = totalNeeds(needs);
@@ -330,7 +340,7 @@ export const evaluateOverview = (data = {}) => {
   const scarcity = scarcityModel(pool, teams, rules);
   const costFor = (item) =>
     estimatedCost(item, market, scarcity, valuation.normalizedFvm);
-  const budgetPlan = roleBudgetPlan(records, 0, needs, rules);
+  const budgetPlan = roleBudgetPlan(records, ownerIndex, needs, rules);
 
   const plans = Object.fromEntries(
     roles.map((role) => {
@@ -392,8 +402,8 @@ export const evaluateOverview = (data = {}) => {
     priorities,
     rolePlan: plans,
     summary: {
-      owner: 0,
-      ownerName: team.name || "Squadra 1",
+      owner: ownerIndex,
+      ownerName: team.name || `Squadra ${ownerIndex + 1}`,
       credits,
       reservedCredits,
       spendableCredits,

--- a/web/tests/simulation.worker.test.js
+++ b/web/tests/simulation.worker.test.js
@@ -176,6 +176,28 @@ test("owner index changes the evaluated team summary and limits", () => {
   assert.equal(constrained.legalMax, 22);
 });
 
+test("overview uses the selected owner instead of the first team", () => {
+  const teams = [
+    team("Rich", 100, {}),
+    team("Mine", 25, { P: 1, D: 1, C: 1, A: 1 }),
+  ];
+  const remaining = [player("P"), player("D"), player("C"), player("A")];
+
+  const result = evaluateOverview({
+    teams,
+    owner: 1,
+    mine: teams[1],
+    remaining,
+    assigned: {},
+  });
+
+  assert.equal(result.summary.owner, 1);
+  assert.equal(result.summary.ownerName, "Mine");
+  assert.equal(result.summary.credits, 25);
+  assert.equal(result.summary.slotsOpen, 4);
+  assert.equal(result.summary.reservedCredits, 4);
+});
+
 test("a full candidate role returns INELIGIBLE", () => {
   const candidate = player("A", 10);
   const teams = [team("Mine", 100, {})];


### PR DESCRIPTION
## Summary

Fixes the auction overview strategy panel so it evaluates the selected user team instead of always using the first team in the teams array.

## Problem

The UI was already passing `owner: userTeamIndex` to the simulation worker for overview requests, but `evaluateOverview` ignored it and always used `teams[0]`.

This caused the overview panel to show incorrect credits, open roster slots, budget planning, and role priorities whenever the user team was not the first team in the participants list.

## Changes

- Resolve `ownerIndex` in `evaluateOverview` using the same logic already used by `evaluateAuction`.
- Use the resolved owner for selected team lookup, role budget planning, and summary owner metadata.
- Add a regression test covering an overview request where the selected team is not `teams[0]`.

## Testing

- `npm test`
- `npm run build`