### PR TITLE
Fix dataset generation with non-finite numeric values

### DIFF
--- a/advisor/pipeline.py
+++ b/advisor/pipeline.py
@@ -348,7 +348,19 @@ def vote_standard_deviation(player_id: int, histories: list[pd.DataFrame], defau
 
 def _clean_record(record: dict) -> dict:
     """Convert pandas scalar nulls to JSON nulls while retaining numeric values."""
-    return {key: (None if pd.isna(value) else value) for key, value in record.items()}
+    return {key: _json_safe(value) for key, value in record.items()}
+
+
+def _json_safe(value):
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (float, np.floating)):
+        return float(value) if np.isfinite(value) else None
+    if pd.isna(value):
+        return None
+    return value
 
 
 def league_rules_payload(league: LeagueConfig) -> dict:
@@ -544,7 +556,7 @@ def build_projections(raw: Path = RAW, output: Path = PROCESSED, config: ModelCo
         "historical": {"matchdays": config.season_days, "label": f"storico {config.season_days}"},
         "current_league": {"serie_a_matchdays": current_matchdays, "label": f"lega corrente {len(current_matchdays)}"},
     }
-    payload = {"schema_version": "1.0", "model_version": "1.6", "players": players, "teams": team_records, "set_pieces": set_piece_records, "league_rules": league_rules, "calendario_serie_a": calendar_records, "calendario_lega": league_calendar, "meta": {"generato_il": datetime.now(timezone.utc).isoformat(), "versione_modello": "1.6", "profile": profile_meta, "horizons": horizons, "assunzioni": "75 minuti per voto; disponibilita da status e storico; gerarchia portieri esplicita; malus portieri incluso; lineup auto nel simulatore"}}
+    payload = _json_safe({"schema_version": "1.0", "model_version": "1.6", "players": players, "teams": team_records, "set_pieces": set_piece_records, "league_rules": league_rules, "calendario_serie_a": calendar_records, "calendario_lega": league_calendar, "meta": {"generato_il": datetime.now(timezone.utc).isoformat(), "versione_modello": "1.6", "profile": profile_meta, "horizons": horizons, "assunzioni": "75 minuti per voto; disponibilita da status e storico; gerarchia portieri esplicita; malus portieri incluso; lineup auto nel simulatore"}})
     output.mkdir(parents=True, exist_ok=True)
     temporary_path: Path | None = None
     try:

--- a/tests/test_pipeline_projections.py
+++ b/tests/test_pipeline_projections.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from advisor.league_profile import LeagueProfile
-from advisor.pipeline import _clean_record, anonymize_public_calendar, build_projections, fixture_projection_arrays, normalize, vote_standard_deviation, weighted_history, weighted_rate_per_appearance
+from advisor.pipeline import _clean_record, _json_safe, anonymize_public_calendar, build_projections, fixture_projection_arrays, normalize, vote_standard_deviation, weighted_history, weighted_rate_per_appearance
 
 
 def history(mv: float, appearances: int, goals: int = 0) -> pd.DataFrame:
@@ -61,6 +61,13 @@ def test_generation_without_league_calendar_writes_strict_json(tmp_path):
     decoded = json.loads(serialized, parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)))
     assert payload["calendario_lega"] is None
     assert decoded["calendario_lega"] is None
+
+
+def test_json_safe_converts_non_finite_values_in_nested_payloads():
+    result = _json_safe({"projection": [float("nan"), float("inf"), 6.5]})
+
+    assert result == {"projection": [None, None, 6.5]}
+    json.dumps(result, allow_nan=False)
 
 
 def test_fixture_projections_vary_by_opponent_venue_and_rotation():


### PR DESCRIPTION
## Summary

Fixes dataset generation failing with:

`Out of range float values are not JSON compliant: nan`

The pipeline now recursively converts non-finite numeric values such as `NaN` and `Infinity` to JSON `null` before writing `auction_data.json`.

This covers values nested inside dictionaries and lists while preserving valid numeric values.

## Testing

- `python -m pytest tests/test_pipeline_projections.py -q`
- Result: `9 passed`